### PR TITLE
Windowresize

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,13 +16,13 @@
       }
     </style>
   </head>
-  <body>
+  <body onresize="windowresize()">
     <div id="ping"></div>
     <form id="options">
       <label for="autoscroll">Autoscroll</label>
       <input type="checkbox" id="autoscroll" checked>
     </form>
-    <div id="legend"></div>
+    <div id="legend"></div> 
     <script defer src="/initial"></script>
     <script id="update"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
         float: right;
       }
       div#legend span.highlight {
-        background-color: #ffff66;
+        background-color: #dddddd;
+        padding: 5px;
       }
     </style>
   </head>

--- a/initial.js
+++ b/initial.js
@@ -123,4 +123,11 @@ function update() {
     }
 }
 
+function windowresize()
+{
+    document.getElementById('ping').style.width = (window.innerWidth * 0.95)+"px";
+    document.getElementById('ping').style.height = (window.innerHeight / 2)+"px";    
+}
+
+
 window.setInterval(update, {{$.Delay}});


### PR DESCRIPTION
The Graph does not resize when you resize the browser window.

I was about to raise an issue/FR for this then I thought i'd take the challenge.

I'm not a webdesigner/JS expert. It works for me, if you know a better way, I'm happy to learn how this is done correctly.

I have tried to actually do

```
g.updateOptions ({        
width: window.innerWidth * 0.95,
        height: window.innerHeight / 2}
)
```
 in   **windowresize()**, but that simply wouldn't want to work.

(https://dygraphs.com/jsdoc/symbols/Dygraph.html#updateOptions) 
