### PR TITLE
Added MimeType for outgoing intial/delta Datasets, otherwise CSP migh…

### DIFF
--- a/webui.go
+++ b/webui.go
@@ -46,6 +46,7 @@ func render_js_template(t *template.Template, w http.ResponseWriter, r *http.Req
 		log.Println("error rendering delta", err)
 		return
 	}
+	// Add Content-Type javascript to please the Content Security Policies
 	w.Header().Add("Content-Type", "text/javascript")
 	// strip the <script>...</script> tags added in open_js_template
 	out := buf.Bytes()
@@ -110,7 +111,7 @@ func webui_worker(db *sql.DB) {
 			"Ordered": ordered,
 			"Points":  points,
 			"MinData": display.Seconds() / interval.Seconds(),
-		})        
+		})
 	})
 
 	http.ListenAndServe(*port, nil)

--- a/webui.go
+++ b/webui.go
@@ -46,6 +46,7 @@ func render_js_template(t *template.Template, w http.ResponseWriter, r *http.Req
 		log.Println("error rendering delta", err)
 		return
 	}
+	w.Header().Add("Content-Type", "text/javascript")
 	// strip the <script>...</script> tags added in open_js_template
 	out := buf.Bytes()
 	_, err = w.Write(out[8 : len(out)-9])
@@ -109,7 +110,7 @@ func webui_worker(db *sql.DB) {
 			"Ordered": ordered,
 			"Points":  points,
 			"MinData": display.Seconds() / interval.Seconds(),
-		})
+		})        
 	})
 
 	http.ListenAndServe(*port, nil)


### PR DESCRIPTION
Added MimeType for outgoing intial/delta Datasets, otherwise CSP might be a problem.

I recently installed an instance of pingwatch on my VPS. As it is reachable from the internet, i put it behind nginx (reverse proxy) to have authentication and TLS.

Apparently, when you use TLS, firefox first complained, that the MimeTypes are not correct:

e.g. 

`The resource from “https://ping.mydomain.tld/initial” was blocked due to MIME type (“text/plain”) mismatch (X-Content-Type-Options: nosniff).`

I'm not sure if this is the best way to do it, but after adding this line, the build still runs through and it works.
(Tbh: i still get some HTTP 500, but I'm very sure this is due to SSOWat, and after that first request, all subsequent work fine.)