### PR TITLE
Added commandline flags to add or remove a host from destinations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ insert into dests values ('1.1.1.1'), ('8.8.8.8'), ('www.google.com');
 EOF
 ```
 
+After database is initialized you can add or delete destinations as follows:
+
+To add a destination, run:
+
+```
+pingwatch -add example.com
+```
+
+To remove a destination, run:
+
+```
+pingwatch -del example.com
+```
+
+
 ### Measurement data
 
 The actual measurements are in the table `pings`:

--- a/db.go
+++ b/db.go
@@ -44,6 +44,22 @@ func get_dests(db *sql.DB) []string {
 	return dests
 }
 
+func db_add_dest(db *sql.DB, host string) {
+    log.Printf("adding host %s", host)
+    _ , err := db.Exec("insert into dests (host) values (?)", host);
+    if err != nil {
+		log.Fatal("could not insert host into destinations", err)
+	}
+}
+
+func db_del_dest(db *sql.DB, host string) {
+    log.Printf("deleting host %s", host)
+    _ , err := db.Exec("delete from dests where host=?", host);
+    if err != nil {
+		log.Fatal("could not insert host into destinations", err)
+	}
+}
+
 func record(db *sql.DB, r *Result) {
 	if *verbose {
 		log.Printf("ping %s(%s) = %v\n", r.Host, r.IP, r.Rtt)

--- a/db.go
+++ b/db.go
@@ -56,7 +56,7 @@ func db_del_dest(db *sql.DB, host string) {
     log.Printf("deleting host %s", host)
     _ , err := db.Exec("delete from dests where host=?", host);
     if err != nil {
-		log.Fatal("could not insert host into destinations", err)
+		log.Fatal("could not delete host from destinations", err)
 	}
 }
 

--- a/pingwatch.go
+++ b/pingwatch.go
@@ -24,11 +24,15 @@ var (
 	interval   *time.Duration
 	display    *time.Duration
 	port       *string
+	addhost    *string
+	delhost    *string	
 )
 
 func main() {
 	// command-line options
 	verbose = flag.Bool("v", false, "Verbose error reporting")
+    addhost = flag.String("add","","Add a host to list of ping destinations")
+    delhost = flag.String("del","","Delete a host from list of ping destinations")
 	cpuprofile := flag.String("cpuprofile", "", "write cpu profile to file")
 	dsn := flag.String("db", "pingwatch.sqlite", "SQLite DB to use for the search index")
 	interval = flag.Duration("interval", 60*time.Second, "ping interval in seconds")
@@ -55,6 +59,44 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
+    if *addhost != "" {
+
+        
+    log.Printf("Adding host %s", *addhost)
+    if *dsn != "" {
+		db, err = sql.Open("sqlite3", *dsn)
+		if err != nil {
+			log.Fatalf("ERROR: opening SQLite DB %q, error: %s", *dsn, err)
+		}
+    
+    
+        db_add_dest (db, *addhost)
+    
+    }
+    
+    
+    
+    
+    os.Exit(0)   
+    }
+
+    if *delhost != "" {
+     
+    if *dsn != "" {
+		db, err = sql.Open("sqlite3", *dsn)
+		if err != nil {
+			log.Fatalf("ERROR: opening SQLite DB %q, error: %s", *dsn, err)
+		}
+    
+    
+        db_del_dest (db, *delhost)
+    
+    }
+    
+    os.Exit(0)          
+    }
+    
+    
 	log.Println("starting pingwatch")
 
 	end := make(chan os.Signal)
@@ -70,6 +112,8 @@ func main() {
 		}
 	}()
 
+    
+    
 	if *dsn != "" {
 		db, err = sql.Open("sqlite3", *dsn)
 		if err != nil {

--- a/pingwatch.go
+++ b/pingwatch.go
@@ -25,7 +25,7 @@ var (
 	display    *time.Duration
 	port       *string
 	addhost    *string
-	delhost    *string	
+	delhost    *string
 )
 
 func main() {
@@ -60,43 +60,27 @@ func main() {
 	}
 
     if *addhost != "" {
-
-        
-    log.Printf("Adding host %s", *addhost)
-    if *dsn != "" {
-		db, err = sql.Open("sqlite3", *dsn)
-		if err != nil {
-			log.Fatalf("ERROR: opening SQLite DB %q, error: %s", *dsn, err)
-		}
-    
-    
-        db_add_dest (db, *addhost)
-    
-    }
-    
-    
-    
-    
-    os.Exit(0)   
+        if *dsn != "" {
+            db, err = sql.Open("sqlite3", *dsn)
+            if err != nil {
+                log.Fatalf("ERROR: opening SQLite DB %q, error: %s", *dsn, err)
+            }
+            db_add_dest (db, *addhost)
+        }
+        os.Exit(0)
     }
 
     if *delhost != "" {
-     
-    if *dsn != "" {
-		db, err = sql.Open("sqlite3", *dsn)
-		if err != nil {
-			log.Fatalf("ERROR: opening SQLite DB %q, error: %s", *dsn, err)
-		}
-    
-    
-        db_del_dest (db, *delhost)
-    
+        if *dsn != "" {
+            db, err = sql.Open("sqlite3", *dsn)
+            if err != nil {
+                log.Fatalf("ERROR: opening SQLite DB %q, error: %s", *dsn, err)
+            }
+            db_del_dest (db, *delhost)
+        }
+        os.Exit(0)
     }
-    
-    os.Exit(0)          
-    }
-    
-    
+
 	log.Println("starting pingwatch")
 
 	end := make(chan os.Signal)
@@ -111,9 +95,6 @@ func main() {
 			dump_goroutines()
 		}
 	}()
-
-    
-    
 	if *dsn != "" {
 		db, err = sql.Open("sqlite3", *dsn)
 		if err != nil {


### PR DESCRIPTION
Summary:
- Added two functions to db.go to add/remove entries to dests table.
- Added two commandline flags that call these functions and then exit pingwatch without starting ping.
- Adapted README.md

To add a destination, run:
```
pingwatch -add example.com
```
To remove a destination, run:
```
pingwatch -del example.com
```



Feel free to adapt/improve code. I guess there might be some room for improvement. Code builds and works fine for me, sofar.